### PR TITLE
bump dispatch-json4s-native to 0.11.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions in ThisBuild ++= Seq(Opts.compile.deprecation) ++
   Seq("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint", "-feature").filter(
     Function.const(scalaVersion.value.startsWith("2.11")))
 
-libraryDependencies ++= Seq("net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.2")
+libraryDependencies ++= Seq("net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.3")
 
 initialCommands := "import scala.concurrent.ExecutionContext.Implicits.global;"
 


### PR DESCRIPTION
Update this library to 0.11.3 which updates async-http-client to a 1.9.x.